### PR TITLE
Check for valid slot in chest instead of using can_insert

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -73,7 +73,7 @@ function on_player_died(event)
 										item.count = item.count - 10
 									end
 								end
-								if chestinventory ~= nil and chestinventory.can_insert(item) then
+								if chestinventory ~= nil and #chestinventory >= chestitems + 1 then
 									chestitems = chestitems + 1
 									chestinventory[chestitems].set_stack(item)
 									transfered = transfered + 1


### PR DESCRIPTION
This ensures that `chestinventory[chestitems]` will not crash due to an "Index out of inventory bounds." error.
